### PR TITLE
Version 0.7

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,23 +18,48 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
 
 ** Keybindings
 
-   |----------------+---------------------------|
-   | key            | explanation               |
-   |----------------+---------------------------|
-   | M-ret          | insert heading            |
-   | TAB            | fold / unfold headings    |
-   | gh, gj, gk, gl | navigate between elements |
-   | vae            | select an element         |
-   | var            | select a subtree          |
-   | M-h or <<      | promote a heading         |
-   | M-l or >>      | demote a heading          |
-   | M-k            | move subtree up           |
-   | M-j            | move subtree down         |
-   | M-S-h or <ar   | promote a subtree         |
-   | M-S-l or >ar   | demote a subtree          |
-   |----------------+---------------------------|
-
    [[file:doc/keythemes.org][Full overview of bindings and configuration]]
+
+*** Quick overview
+
+    |----------------+---------------------------|
+    | key            | explanation               |
+    |----------------+---------------------------|
+    | gh, gj, gk, gl | navigate between elements |
+    | vae            | select an element         |
+    |----------------+---------------------------|
+
+**** Headings and items
+
+     |--------------+------------------------|
+     | key          | explanation            |
+     |--------------+------------------------|
+     | M-ret        | insert heading         |
+     | TAB          | fold / unfold headings |
+     | M-h or <<    | promote a heading      |
+     | M-l or >>    | demote a heading       |
+     | M-k          | move subtree up        |
+     | M-j          | move subtree down      |
+     | M-S-h or <aR | promote a subtree      |
+     | M-S-l or >aR | demote a subtree       |
+     | vaR          | select a subtree       |
+     |--------------+------------------------|
+
+**** Tables
+
+     |-----------+--------------------------------|
+     | key       | explanation                    |
+     |-----------+--------------------------------|
+     | (         | previous table cell            |
+     | )         | next table cell                |
+     | {         | beginning of table             |
+     | }         | end of table                   |
+     | M-h / M-l | move table column left / right |
+     | M-k / M-j | move table column up / down    |
+     | vae       | select table cell              |
+     | vaE       | select table row               |
+     | var       | select whole table             |
+     |-----------+--------------------------------|
 
 ** Requirements
 

--- a/doc/changelog.org
+++ b/doc/changelog.org
@@ -5,6 +5,8 @@
   #+END_SRC
   This line is from now on required in a user config.
   
+  - Leader key bindings are removed. See [[file:example_config.el][example config]] for an example how you can set them up yourself.
+  
 * Between versions 0.1.2 and 0.6.3
   - less controversial default keybindings (see issue [[https://github.com/edwtjo/evil-org-mode/issues/13][#13]])
     t, T, O and leader bindings are no longer bound by default, but can be enabled using key themes.

--- a/doc/changelog.org
+++ b/doc/changelog.org
@@ -1,3 +1,10 @@
+* Version 0.7.0
+  - A hook is no longer created automatically
+  #+BEGIN_SRC emacs-lisp
+  (add-hook 'org-mode-hook 'evil-org-mode) ;; only load with org-mode
+  #+END_SRC
+  This line is from now on required in a user config.
+  
 * Between versions 0.1.2 and 0.6.3
   - less controversial default keybindings (see issue [[https://github.com/edwtjo/evil-org-mode/issues/13][#13]])
     t, T, O and leader bindings are no longer bound by default, but can be enabled using key themes.

--- a/doc/changelog.org
+++ b/doc/changelog.org
@@ -1,18 +1,25 @@
-* Version 0.7.0
-  - A hook is no longer created automatically
+* Version 0.7.*
+  - A hook is no longer created automatically. The following line of code is from now on required in a user config:
   #+BEGIN_SRC emacs-lisp
   (add-hook 'org-mode-hook 'evil-org-mode) ;; only load with org-mode
   #+END_SRC
-  This line is from now on required in a user config.
-  
   - Leader key bindings are removed. See [[file:example_config.el][example config]] for an example how you can set them up yourself.
+  - Redone text objects
+    - Sentence (is/as) and paragraph (ip/ap) text objects no longer get special treatment in tables. Use ie/ae for cells and ir/ar for tables instead.
+    - Move element text object bindings from ie/ae to iE/aE
+    - New text object ie/ae that works on elements and a few smaller objects.
+    - Move subtree text object bindings from ir/ar to iR/aR
+    - New text object ir/ar that works on recursive objects. Repeatable in visual mode.
   
 * Between versions 0.1.2 and 0.6.3
   - less controversial default keybindings (see issue [[https://github.com/edwtjo/evil-org-mode/issues/13][#13]])
     t, T, O and leader bindings are no longer bound by default, but can be enabled using key themes.
   - leader keys are deprecated and evil-leader is no longer required
   - customizable movement keys (as a courtesy to dvorak users)
-  - operators (>, <) for promotion, demotion. Can also be used for plain indentation when in a code block
-  - text objects (ae, ar, ap, as)
+  - new operators (>, <) for promotion, demotion. Can also be used for plain indentation when in a code block.
+    That means < and > are no longer bound to org-meta-left/right.
+  - new text objects
+    - ae, ar to match element, subheading
+    - ap, as to match whole table, table cell in table context
   - optional insert mode bindings C-d and C-t
   - table support for keys: x, X, (, ), { and }.

--- a/doc/keythemes.org
+++ b/doc/keythemes.org
@@ -5,7 +5,7 @@
   To enable all bindings use:
 
   #+begin_src emacs-lisp
-  (evil-org-set-key-theme '(textobjects insert navigation additional shift leader todo heading))
+  (evil-org-set-key-theme '(textobjects insert navigation additional shift todo heading))
   #+end_src
 
 ** Basic
@@ -129,16 +129,3 @@
    | M-o | org-insert-heading+org-metaright |
    |-----+----------------------------------|
 
-** Leader                                                        :deprecated:
-   Disabled by default.
-
-   |-----------+---------------------------|
-   | key       | function                  |
-   |-----------+---------------------------|
-   | <leader>a | org-agenda                |
-   | <leader>t | org-show-todo-tree        |
-   | <leader>c | org-archive-subtree       |
-   | <leader>l | evil-org-open-links       |
-   | <leader>o | evil-org-recompute-clocks |
-   |-----------+---------------------------|
-  

--- a/doc/keythemes.org
+++ b/doc/keythemes.org
@@ -66,17 +66,18 @@
    |-----+----------------------+-------------------|
 
 ** Text objects
-   "var" to select an element
+   "vae" to select an element
    "dar" to delete a subtree
-   "2yar" to yank the parent of a subtree
+   "2yaR" to yank the parent of a subtree
 
-  |-----+-------------+------------------------------------------------|
-  | key | function    | explanation                                    |
-  |-----+-------------+------------------------------------------------|
-  | ae  | org-element | An org element                                 |
-  | ar  | org-subtree | A subtree. Use a count to select parent trees. |
-  |-----+-------------+------------------------------------------------|
-
+  |---------+---------------------+-------------------------------------------------|
+  | key     | function            | explanation                                     |
+  |---------+---------------------+-------------------------------------------------|
+  | ae / ie | org-object          | An / inner object (markup, table cell)          |
+  | aE / iE | org-element         | An / inner element (code block, table row)      |
+  | ar / ir | org-greater-element | An / inner recursive element (item list, table) |
+  | aR / iR | org-subtree         | An / inner subtree starting with a *            |
+  |---------+---------------------+-------------------------------------------------|
 
 ** Additional
    If you don't want to use hjkl, you can customize evil-org-movement-bindings.

--- a/evil-org.el
+++ b/evil-org.el
@@ -7,7 +7,7 @@
 ;; Git-Repository: git://github.com/Somelauw/evil-org-mode.git
 ;; Created: 2012-06-14
 ;; Forked-since: 2017-02-12
-;; Version: 0.6.3
+;; Version: 0.7.0
 ;; Package-Requires: ((emacs "24.4") (evil "1.0") (org "8.0.0"))
 ;; Keywords: evil vim-emulation org-mode key-bindings presets
 
@@ -25,6 +25,9 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+;; Minimal config
+;; (add-hook 'org-mode-hook 'evil-org-mode)
 
 ;;; Commentary:
 ;;
@@ -81,8 +84,6 @@ arguments."
               (const todo)
               (const heading)
               (const leader)))
-
-(add-hook 'org-mode-hook 'evil-org-mode) ;; only load with org-mode
 
 ;;; Variable declarations
 (defvar browse-url-generic-program)

--- a/evil-org.el
+++ b/evil-org.el
@@ -7,7 +7,7 @@
 ;; Git-Repository: git://github.com/Somelauw/evil-org-mode.git
 ;; Created: 2012-06-14
 ;; Forked-since: 2017-02-12
-;; Version: 0.7.2
+;; Version: 0.7.3
 ;; Package-Requires: ((emacs "24.4") (evil "1.0") (org "8.0.0"))
 ;; Keywords: evil vim-emulation org-mode key-bindings presets
 
@@ -119,35 +119,23 @@ FUN function callback"
   "Clever insertion of org item.
 Argument COUNT number of lines to insert."
   (interactive "p")
-  (cond ((org-at-table-p)
-         (org-table-insert-row '(4))
-         (evil-insert count))
-        ((org-in-item-p)
-         (end-of-visible-line)
-         (org-insert-item)
-         (evil-append count))
-        (t (evil-open-below count))))
+  (end-of-visible-line)
+  (let ((e (org-element-lineage (org-element-at-point) '(item table-row) t)))
+    (case (org-element-type e)
+      ((table-row) (org-table-insert-row '(4)) (evil-insert nil))
+      ((item) (org-insert-item) (evil-append nil))
+      (otherwise (evil-open-below count)))))
 
 (defun evil-org-open-above (count)
   "Clever insertion of org item.
 Argument COUNT number of lines to insert."
   (interactive "p")
-  (cond ((org-at-table-p)
-         (org-table-insert-row)
-         (evil-insert count))
-        ((org-in-item-p)
-         (beginning-of-visual-line)
-         (org-insert-item)
-         (evil-append count))
-        (t (evil-open-above count))))
-
-(defun evil-org-insert-below (count)
-  "Insert heading or item below.
-Argument COUNT number of lines to insert."
-  (interactive "p")
   (end-of-visible-line)
-  (org-meta-return)
-  (evil-append count))
+  (let ((e (org-element-lineage (org-element-at-point) '(item table-row) t)))
+    (case (org-element-type e)
+      ((table-row) (org-table-insert-row) (evil-insert nil))
+      ((item) (beginning-of-visual-line) (org-insert-item) (evil-append nil))
+      (otherwise (evil-open-above count)))))
 
 (defun evil-org-insert-subheading (&optional arg)
   "Insert new subheading.

--- a/evil-org.el
+++ b/evil-org.el
@@ -7,7 +7,7 @@
 ;; Git-Repository: git://github.com/Somelauw/evil-org-mode.git
 ;; Created: 2012-06-14
 ;; Forked-since: 2017-02-12
-;; Version: 0.7.0
+;; Version: 0.7.1
 ;; Package-Requires: ((emacs "24.4") (evil "1.0") (org "8.0.0"))
 ;; Keywords: evil vim-emulation org-mode key-bindings presets
 
@@ -41,7 +41,6 @@
 (require 'org)
 (require 'org-element)
 (require 'org-table)
-(require 'leader nil 'noerror)
 
 (defgroup evil-org nil
   "Provides integration of org-mode and evil."
@@ -561,17 +560,6 @@ If a prefix argument is given, links are opened in incognito mode."
                     (org-insert-heading))))
     (kbd "M-o") 'evil-org-insert-subheading))
 
-;; leader maps
-(defun evil-org--populate-leader-bindings ()
-  "Leader bindings (deprecated)."
-  (make-obsolete 'leader "please bind leader keys in your local config." "0.5.0")
-  (evil-leader/set-key-for-mode 'org-mode
-    "t" 'org-show-todo-tree
-    "a" 'org-agenda
-    "c" 'org-archive-subtree
-    "l" 'evil-org-open-links
-    "o" 'evil-org-recompute-clocks))
-
 ;;;###autoload
 (defun evil-org-set-key-theme (&optional theme)
   "Select what keythemes to enable.
@@ -587,7 +575,6 @@ Optional argument THEME list of themes. See evil-org-keytheme for a list of valu
     (when (memq 'shift theme) (evil-org--populate-shift-bindings))
     (when (memq 'todo theme) (evil-org--populate-todo-bindings))
     (when (memq 'heading theme) (evil-org--populate-heading-bindings))
-    (when (memq 'leader theme) (evil-org--populate-leader-bindings))
     (setcdr
      (assq 'evil-org-mode minor-mode-map-alist)
      evil-org-mode-map)))


### PR DESCRIPTION
I'm considering these changes for the next version:

  - A hook is no longer created automatically. The following line of code is from now on required in a user config:
  ```emacs-lisp
  (add-hook 'org-mode-hook 'evil-org-mode) ;; only load with org-mode
  ```
  - Leader key bindings are removed. See [example config](./example_config.el) for an example how you can set them up yourself.
  - Redone text objects
    - Sentence (is/as) and paragraph (ip/ap) text objects no longer get special treatment in tables. Use ie/ae for cells and ir/ar for tables instead.
    - Move element text object bindings from ie/ae to iE/aE
    - New text object ie/ae that works on elements and a few smaller objects.
    - Move subtree text object bindings from ir/ar to iR/aR
    - New text object ir/ar that works on recursive objects. Repeatable in visual mode.