### PR TITLE
README.org: evil-mode link: bitbucket to github

### DIFF
--- a/README.org
+++ b/README.org
@@ -64,7 +64,7 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
 ** Requirements
 
    - org-mode, git://orgmode.org/org-mode.git
-   - evil-mode, https://bitbucket.org/lyro/evil
+   - evil-mode, https://github.com/emacs-evil/evil
 
 ** Installation
 


### PR DESCRIPTION
The evil repository has migrated from bitbucket to github.