### PR TITLE
Fix org-cycle hotkey in terminal emacs

### DIFF
--- a/evil-org.el
+++ b/evil-org.el
@@ -508,7 +508,7 @@ Includes tables, list items and subtrees."
       (evil-define-key state evil-org-mode-map
         (kbd "<") 'evil-org-promote-or-dedent
         (kbd ">") 'evil-org-demote-or-indent
-        (kbd "<tab>") 'org-cycle
+        (kbd "TAB") 'org-cycle
         (kbd "<S-tab>") 'org-shifttab))
     (evil-define-key 'normal evil-org-mode-map
       (kbd "o") 'evil-org-open-below


### PR DESCRIPTION
When running emacs in the terminal <tab> isn't registered. (At least on gnome-shell on ubuntu). I wouldn't be offended if you don't accept this pr, I'm not sure what the consequences for other users might be although it works fine in both GUI and terminal for me.