### PR TITLE
Explain how to fix `TAB` not working as expected

### DIFF
--- a/README.org
+++ b/README.org
@@ -102,7 +102,7 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
 
 For a more elaborate setup, take a look at [[file:doc/example_config.el][this example]].
 
-In the case where you run into trouble with =TAB= does not work as expected (being binded to =evil-jump-forward=), you might want to add this to your configuration =(setq evil-want-C-i-jump nil)=.
+In the case where you run into trouble with =TAB= does not work as expected (being binded to =evil-jump-forward=), you might want to add this to your configuration =(setq evil-want-C-i-jump nil)= before =evil= is loaded.
 
 ** See also
 

--- a/README.org
+++ b/README.org
@@ -102,6 +102,8 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
 
 For a more elaborate setup, take a look at [[file:doc/example_config.el][this example]].
 
+In the case where you run into trouble with =TAB= does not work as expected (being binded to =evil-jump-forward=), you might want to add this to your configuration =(setq evil-want-C-i-jump nil)=.
+
 ** See also
 
    - [[https://github.com/edwtjo/evil-org-mode][evil-org-mode by edwtjo]]


### PR DESCRIPTION
`TAB` won't work as expected in some cases. I ran into this problem and I found out all you have to do is to disable `evil-want-C-i-jump`. Source: https://stackoverflow.com/questions/22878668/emacs-org-mode-evil-mode-tab-key-not-working

By the way, great work guys! 👍 👍 👍 