### PR TITLE
Restore additional-bindings in normal mode

### DIFF
--- a/evil-org.el
+++ b/evil-org.el
@@ -68,7 +68,7 @@
 (defcustom evil-org-key-theme
   (if (bound-and-true-p evil-disable-insert-state-bindings)
       '(textobjects navigation additional)
-      '(textobjects navigation insert additional))
+    '(textobjects navigation insert additional))
   "Which key themes to enable.
 If you use this variable, you should call `evil-org-set-key-theme' with zero
 arguments."
@@ -112,7 +112,7 @@ By default, o and O are bound to ‘evil-org-open-above’ and ‘evil-org-open-
   :lighter " EvilOrg"
   :keymap evil-org-mode-map
   :group 'evil-org
-)
+  )
 
 (defun evil-org-eol-call (fun &rest arguments)
   "Go to end of line and call provided function.
@@ -366,8 +366,8 @@ Argument INCOG whether to open in incognito mode."
             (throw 'break 0))
           (if (not (null incog))
               (evil-org-open-incognito)
-             (let ((browse-url-generic-args '("")))
-               (org-open-at-point '(16)))))))))
+            (let ((browse-url-generic-args '("")))
+              (org-open-at-point '(16)))))))))
 
 (defun evil-org-open-incognito ()
   "Open link in new incognito window."
@@ -594,7 +594,7 @@ Includes tables, list items and subtrees."
   "Bindings with meta and control."
   (let-alist evil-org-movement-bindings
     (let ((state (if evil-org-use-additional-insert
-                     '('normal visual insert)
+                     '(normal visual insert)
                    '(normal visual))))
       (evil-define-key state evil-org-mode-map
         (kbd (concat "M-" .left)) 'org-metaleft


### PR DESCRIPTION
When evil-org-use-additional-insert was true the documentation said it should activate "additional bindings" for "insert" mode in addition to "normal" and "visual" mode. However due to a misplaced quote the bindings for "normal" mode were omitted which is what I have fixed.