### PR TITLE
Update installation guilde using use-package

### DIFF
--- a/README.org
+++ b/README.org
@@ -160,7 +160,9 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
       (add-hook 'org-mode-hook 'evil-org-mode)
       (add-hook 'evil-org-mode-hook
                 (lambda ()
-                  (evil-org-set-key-theme))))
+                  (evil-org-set-key-theme)))
+      (require 'evil-org-agenda)
+      (evil-org-agenda-set-keys))
     #+END_SRC
 
     For a more elaborate setup, take a look at [[file:doc/example_config.el][this example]].


### PR DESCRIPTION
The current installation guide for `use-package` is missing a setting
for `evil-org-agenda`. This PR adds it so that we can simply copy and
paste the installation guide to our config file :)