### PR TITLE
Fix key bindings for org-agenda-mode-map

### DIFF
--- a/README.org
+++ b/README.org
@@ -99,6 +99,7 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
      | x                       | B                       | execute action on marks                                                           |
      | gr                      | r                       | refresh agenda                                                                    |
      | gR                      | g                       | refresh all agendas                                                               |
+     | S                       | s                       | save all org buffers                                                             |
      | ZQ                      | x                       | exit agenda                                                                       |
      | ZZ                      | Q                       | quit agenda                                                                       |
      | z                       | v                       | tweak display (deadlines, diary, follow/log-mode, entry text, grid, day/week/year |

--- a/evil-org-agenda.el
+++ b/evil-org-agenda.el
@@ -158,6 +158,7 @@
     "P" 'org-agenda-show-the-flagging-note
 
     ;; 'org-save-all-org-buffers ; Original binding "C-x C-s"
+    "S" 'org-save-all-org-buffers
 
     ;; Others
     "+" 'org-agenda-manipulate-query-add

--- a/evil-org-agenda.el
+++ b/evil-org-agenda.el
@@ -135,7 +135,7 @@
     "st" 'org-agenda-filter-by-tag
     "s^" 'org-agenda-filter-by-top-headline
     "ss" 'org-agenda-limit-interactively
-    "S" 'org-agenda-filter-remove-all
+    "su" 'org-agenda-filter-remove-all
 
     ;; clock
     "I" 'org-agenda-clock-in ; Original binding


### PR DESCRIPTION
The document says that `su` to remove all filters but `org-agenda-filter-remove-all` are set to `S` in evil-org-agenda.el. 

AIso I think `org-save-all-org-buffers` is important commands in org-agenda buffer.