### PR TITLE
Add 'gx' bind to open links in visual and normal modes, make a unit test more robust

### DIFF
--- a/README.org
+++ b/README.org
@@ -28,6 +28,7 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
     | key            | explanation               |
     |----------------+---------------------------|
     | gh, gj, gk, gl | navigate between elements |
+    | gx             | open a link               |
     | vae            | select an element         |
     |----------------+---------------------------|
 
@@ -138,12 +139,12 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
 **** Configuration emacs.el
 
     #+BEGIN_SRC emacs-lisp
-    (add-to-list 'load-path "~/.emacs.d/plugins/evil-org")
-    (require 'evil-org)
-    (add-hook 'org-mode-hook 'evil-org-mode)
-    (evil-org-set-key-theme '(navigation insert textobjects additional calendar))
-    (require 'evil-org-agenda)
-    (evil-org-agenda-set-keys)
+      (add-to-list 'load-path "~/.emacs.d/plugins/evil-org")
+      (require 'evil-org)
+      (add-hook 'org-mode-hook 'evil-org-mode)
+      (evil-org-set-key-theme '(navigation insert link textobjects additional calendar))
+      (require 'evil-org-agenda)
+      (evil-org-agenda-set-keys)
     #+END_SRC
 
     Or you can customize =evil-org-key-theme= and replace the last line by:

--- a/evil-org-test.el
+++ b/evil-org-test.el
@@ -120,7 +120,7 @@
                  (evil-org-with
                   "* |Funny heading with some text                                     :testcase:"
                   (let ((w (evil-a-word)))
-                    (evil-org-delete (first w) (second w)))))))
+                    (evil-org-delete (car w) (cadr w)))))))
 
 ;; TODO test x and X
 ;; TODO test < and >

--- a/evil-org.el
+++ b/evil-org.el
@@ -51,14 +51,15 @@
 ;;; Customizations
 (defcustom evil-org-key-theme
   (if (bound-and-true-p evil-disable-insert-state-bindings)
-      '(navigation textobjects additional calendar)
-    '(navigation insert textobjects additional calendar))
+      '(navigation link textobjects additional calendar)
+    '(navigation insert link textobjects additional calendar))
   "Which key themes to enable.
 If you use this variable, you should call `evil-org-set-key-theme' with zero
 arguments."
   :group 'evil-org
   :type '(set (const navigation)
               (const insert)
+              (const link)
               (const return)
               (const textobjects)
               (const additional)
@@ -679,6 +680,11 @@ Includes tables, list items and subtrees."
     (kbd "C-t") 'org-metaright
     (kbd "C-d") 'org-metaleft))
 
+(defun evil-org--populate-link-bindings ()
+  "Define link bindings."
+  (let ((state '(visual normal)))
+    (evil-define-key state evil-org-mode-map "gx" 'org-open-at-point)))
+
 (defun evil-org--populate-navigation-bindings ()
   "Configures gj/gk/gh/gl for navigation."
   (let-alist evil-org-movement-bindings
@@ -752,28 +758,28 @@ Includes tables, list items and subtrees."
   (let-alist evil-org-movement-bindings
     (define-key org-read-date-minibuffer-local-map
       (kbd (concat "M-" .left)) (lambda () (interactive)
-                    (org-eval-in-calendar '(calendar-backward-day 1))))
+                                  (org-eval-in-calendar '(calendar-backward-day 1))))
     (define-key org-read-date-minibuffer-local-map
       (kbd (concat "M-" .right)) (lambda () (interactive)
-                    (org-eval-in-calendar '(calendar-forward-day 1))))
+                                   (org-eval-in-calendar '(calendar-forward-day 1))))
     (define-key org-read-date-minibuffer-local-map
       (kbd (concat "M-" .up)) (lambda () (interactive)
-                    (org-eval-in-calendar '(calendar-backward-week 1))))
+                                (org-eval-in-calendar '(calendar-backward-week 1))))
     (define-key org-read-date-minibuffer-local-map
       (kbd (concat "M-" .down)) (lambda () (interactive)
-                    (org-eval-in-calendar '(calendar-forward-week 1))))
+                                  (org-eval-in-calendar '(calendar-forward-week 1))))
     (define-key org-read-date-minibuffer-local-map
       (kbd (concat "M-" (capitalize .left))) (lambda () (interactive)
-                      (org-eval-in-calendar '(calendar-backward-month 1))))
+                                               (org-eval-in-calendar '(calendar-backward-month 1))))
     (define-key org-read-date-minibuffer-local-map
       (kbd (concat "M-" (capitalize .right))) (lambda () (interactive)
-                      (org-eval-in-calendar '(calendar-forward-month 1))))
+                                                (org-eval-in-calendar '(calendar-forward-month 1))))
     (define-key org-read-date-minibuffer-local-map
       (kbd (concat "M-" (capitalize .up))) (lambda () (interactive)
-                      (org-eval-in-calendar '(calendar-backward-year 1))))
+                                             (org-eval-in-calendar '(calendar-backward-year 1))))
     (define-key org-read-date-minibuffer-local-map
       (kbd (concat "M-" (capitalize .down))) (lambda () (interactive)
-                      (org-eval-in-calendar '(calendar-forward-year 1))))))
+                                               (org-eval-in-calendar '(calendar-forward-year 1))))))
 
 (defun evil-org-set-key-theme (&optional theme)
   "Select what keythemes to enable.
@@ -783,6 +789,7 @@ Optional argument THEME list of themes. See evil-org-keytheme for a list of valu
     (evil-org--populate-base-bindings)
     (when (memq 'navigation theme) (evil-org--populate-navigation-bindings))
     (when (memq 'insert theme) (evil-org--populate-insert-bindings))
+    (when (memq 'link evil-org-key-theme) (evil-org--populate-link-bindings))
     (when (memq 'return theme)
       (evil-define-key 'insert evil-org-mode-map (kbd "RET") 'evil-org-return)
       (define-key evil-org-mode-map (kbd "RET") 'evil-org-return))


### PR DESCRIPTION
I've added 'gx' to call `'org-open-at-point' in normal and visual mode because AFAIK there's no evil-ish way to browse links.  

I also fixed a unit test that would fail if (require 'cl) wasn't called before running the tests.  My fix is simply to use car and cadr instead of their aliases first and second to avoid having to call (require 'cl).  I could instead add the require call at the top of the tests file.