### PR TITLE
make RET and TAB bindings work in terminal

### DIFF
--- a/evil-org-agenda.el
+++ b/evil-org-agenda.el
@@ -50,9 +50,13 @@
 
     ;; open
     (kbd "<tab>") 'org-agenda-goto
+    (kbd "TAB") 'org-agenda-goto
     (kbd "<return>") 'org-agenda-switch-to
+    (kbd "RET") 'org-agenda-switch-to
     (kbd "S-<return>") 'org-agenda-goto
+    (kbd "S-RET") 'org-agenda-goto
     (kbd "M-<return>") 'org-agenda-recenter
+    (kbd "M-RET") 'org-agenda-recenter
 
     (kbd "SPC") 'org-agenda-show-and-scroll-up
     (kbd "<delete>") 'org-agenda-show-scroll-down

--- a/evil-org.el
+++ b/evil-org.el
@@ -656,6 +656,7 @@ Includes tables, list items and subtrees."
     (kbd "<C-S-return>") (evil-org-define-eol-command
                           org-insert-todo-heading-respect-content))
   (evil-define-key '(normal visual) evil-org-mode-map
+    (kbd "TAB") 'org-cycle
     (kbd "<tab>") 'org-cycle
     (kbd "<S-tab>") 'org-shifttab
     (kbd "<") 'evil-org-<


### PR DESCRIPTION
Those keys have different key codes in a terminal.

There are also `<delete>` and `<backspace>` which have different codes in the terminal, but I'm not sure which key code should be used.