### PR TITLE
Update repo name in manual install instructions

### DIFF
--- a/README.org
+++ b/README.org
@@ -131,14 +131,14 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
 
 *** Manual installation
     #+BEGIN_SRC sh
-    mkdir -p ~/.emacs.d/plugins; git clone
-    git://github.com/somelauw/evil-org.git ~/.emacs.d/plugins/evil-org
+    mkdir -p ~/.emacs.d/plugins; git clone \
+    git://github.com/somelauw/evil-org-mode.git ~/.emacs.d/plugins/evil-org-mode
     #+END_SRC
 
 **** Configuration emacs.el
 
     #+BEGIN_SRC emacs-lisp
-    (add-to-list 'load-path "~/.emacs.d/plugins/evil-org")
+    (add-to-list 'load-path "~/.emacs.d/plugins/evil-org-mode")
     (require 'evil-org)
     (add-hook 'org-mode-hook 'evil-org-mode)
     (evil-org-set-key-theme '(navigation insert textobjects additional calendar))


### PR DESCRIPTION
When ran the manual installation command, I noticed it was pointing to https://github.com/Somelauw/evil-org, which breaks the configuration (evil-org-agenda is missing in the other repo).