### PR TITLE
Add `g TAB` as a fallback for `<tab>`. Make RET bindings work.

### DIFF
--- a/evil-org-agenda.el
+++ b/evil-org-agenda.el
@@ -50,9 +50,10 @@
 
     ;; open
     (kbd "<tab>") 'org-agenda-goto
-    (kbd "<return>") 'org-agenda-switch-to
     (kbd "S-<return>") 'org-agenda-goto
-    (kbd "M-<return>") 'org-agenda-recenter
+    (kbd "g TAB") 'org-agenda-goto
+    (kbd "RET") 'org-agenda-switch-to
+    (kbd "M-RET") 'org-agenda-recenter
 
     (kbd "SPC") 'org-agenda-show-and-scroll-up
     (kbd "<delete>") 'org-agenda-show-scroll-down

--- a/evil-org.el
+++ b/evil-org.el
@@ -657,7 +657,8 @@ Includes tables, list items and subtrees."
                           org-insert-todo-heading-respect-content))
   (evil-define-key '(normal visual) evil-org-mode-map
     (kbd "<tab>") 'org-cycle
-    (kbd "<S-tab>") 'org-shifttab
+    (kbd "g TAB") 'org-cycle
+    (kbd "<backtab>") 'org-shifttab
     (kbd "<") 'evil-org-<
     (kbd ">") 'evil-org->))
 


### PR DESCRIPTION
* `g TAB` is a good fallback for `<tab>` in terminal environments.
* `RET` can take care of Enter on GUI and in terminal environments.
* `M-RET` can take care of Alt+Enter on GUI and in terminal environments.
* `S-<return>` is removed because it is redundant.