### PR TITLE
Symbol's function definition is void: first

### DIFF
--- a/evil-org-test.el
+++ b/evil-org-test.el
@@ -120,7 +120,7 @@
                  (evil-org-with
                   "* |Funny heading with some text                                     :testcase:"
                   (let ((w (evil-a-word)))
-                    (evil-org-delete (first w) (second w)))))))
+                    (evil-org-delete (cl-first w) (cl-second w)))))))
 
 ;; TODO test x and X
 ;; TODO test < and >

--- a/evil-org.el
+++ b/evil-org.el
@@ -414,7 +414,7 @@ Argument END, second column
 If ARG > 0, move column BEG to END.
 If ARG < 0, move column END to BEG"
   (let* ((text (buffer-substring beg end))
-         (n-cells-selected (max 1 (count ?| text)))
+         (n-cells-selected (max 1 (cl-count ?| text)))
          (n-columns-to-move (* n-cells-selected (abs arg)))
          (move-left-p (< arg 0)))
     (goto-char (if move-left-p end beg))
@@ -591,7 +591,7 @@ Includes tables, list items and subtrees."
   (save-excursion
     (when beg (goto-char beg))
     (let ((element (org-element-at-point)))
-      (when (or (not (memq (first element) org-element-greater-elements))
+      (when (or (not (memq (cl-first element) org-element-greater-elements))
                 (and end (>= end (org-element-property :end element))))
         (setq element (evil-org-parent element)))
       (dotimes (_ (1- count))
@@ -605,7 +605,7 @@ Includes tables, list items and subtrees."
   (save-excursion
     (when beg (goto-char beg))
     (let ((element (org-element-at-point)))
-      (unless (memq (first element) org-element-greater-elements)
+      (unless (memq (cl-first element) org-element-greater-elements)
         (setq element (evil-org-parent element)))
       (dotimes (_ (1- count))
         (setq element (evil-org-parent element)))


### PR DESCRIPTION
I encountered the error in the title when trying the key sequence `v a r`, invoking `evil-org-a-greater-element`, using the pre-release emacs-27.0.91.

`first` is defined in the `cl` library, which is now deprecated, and at any rate is not loaded from `evil-org`. The `cl-lib` defines the alias `cl-first`, so I switched to that. I likewise fixed invocations of `first` and `second` in the test suite, and responded to a compiler warning about `count`.

This seems to all work equally well on emacs-26 and emacs-27.