### PR TITLE
implement use-package `:hook` syntax in readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -160,11 +160,8 @@ See [[file:doc/changelog.org][changelog]] for a history of changes.
     (use-package evil-org
       :ensure t
       :after org
+      :hook (org-mode . (lambda () evil-org-mode))
       :config
-      (add-hook 'org-mode-hook 'evil-org-mode)
-      (add-hook 'evil-org-mode-hook
-                (lambda ()
-                  (evil-org-set-key-theme)))
       (require 'evil-org-agenda)
       (evil-org-agenda-set-keys))
     #+END_SRC


### PR DESCRIPTION
not entirely sure this is what works. Why doesn't evil-org have a hook so that I can `:hook (org-mode . evil-org-mode)`? (which would link to `evil-org-mode-hook`).

Also not sure if I should use a hook to `evil-org-set-key-theme` or put it in config.

Lately my `[` and `]` keys have stopped working in org-agenda.