### PR TITLE
Fix org-agenda-earlier/later keybindings ([ and ])

### DIFF
--- a/evil-org-agenda.el
+++ b/evil-org-agenda.el
@@ -69,8 +69,8 @@
     "gL" 'evil-window-bottom
     (kbd "C-j") 'org-agenda-next-item
     (kbd "C-k") 'org-agenda-previous-item
-    (kbd "[") 'org-agenda-earlier
-    (kbd "]") 'org-agenda-later
+    (kbd "[[") 'org-agenda-earlier
+    (kbd "]]") 'org-agenda-later
 
     ;; manipulation
     ;; We follow standard org-mode bindings (not org-agenda bindings):


### PR DESCRIPTION
evil-mode already binds different combinations of "[" and "]" under
the "motion" state:

https://github.com/emacs-evil/evil/blob/d6cf6680ec52733ea78dc530ed75fadc5171c758/evil-maps.el#L227

Because of this, the current "[" and "]" bindings in org-agenda don't
work, as Emacs expects a follow-up key to be pressed.

To avoid removing these existing bindings, we can instead just re-bind
"[[" and "]]".