### PR TITLE
Add escape binding for clearing search

### DIFF
--- a/evil-org-agenda.el
+++ b/evil-org-agenda.el
@@ -163,6 +163,9 @@
 
     ;; 'org-save-all-org-buffers ; Original binding "C-x C-s"
 
+    ;; clear search
+    (kbd "<escape>") 'evil-force-normal-state
+
     ;; Others
     "+" 'org-agenda-manipulate-query-add
     "-" 'org-agenda-manipulate-query-subtract))


### PR DESCRIPTION
Typically I'll search to a TODO in my agenda to complete it, but then I won't be able to clear the search highlighting -- this PR should fix this