### PR TITLE
Remove evil-digit-bound-motions

### DIFF
--- a/evil-org.el
+++ b/evil-org.el
@@ -632,9 +632,8 @@ Includes tables, list items and subtrees."
 ;;; Keythemes
 (defun evil-org--populate-base-bindings ()
   "Bindings that are always available."
-  (let ((motion-map (evil-get-minor-mode-keymap 'motion 'evil-org-mode)))
-    (evil-redirect-digit-argument motion-map "0" 'evil-org-beginning-of-line))
   (evil-define-key 'motion 'evil-org-mode
+    (kbd "0") 'evil-org-beginning-of-line
     (kbd "$") 'evil-org-end-of-line
     (kbd ")") 'evil-org-forward-sentence
     (kbd "(") 'evil-org-backward-sentence


### PR DESCRIPTION
I've been using the latest commit from my PR, emacs-evil/evil#1534 in my config, and was using evil-org-mode in the following state for a couple weeks now. I can confirm that everything works as intended without line 635. If 1534, above, gets merged, then this PR should be all it takes to fix evil-org-mode when it breaks.