### PR TITLE
Fix incorrect obsolescence declarations

### DIFF
--- a/evil-org.el
+++ b/evil-org.el
@@ -123,7 +123,7 @@ before calling `evil-org-set-keytheme'."
   "Go to end of line and call provided function.
 FUN function callback
 Optional argument ARGUMENTS arguments to pass to FUN."
-  (obsolete 'evil-org-define-bol-command "0.9.4")
+  (declare (obsolete 'evil-org-define-eol-command "0.9.4"))
   (end-of-visible-line)
   (apply fun arguments)
   (evil-insert nil))
@@ -132,7 +132,7 @@ Optional argument ARGUMENTS arguments to pass to FUN."
   "Go to beginning of line and call provided function.
 FUN function callback
 Optional argument ARGUMENTS arguments to pass to FUN."
-  (obsolete 'evil-org-define-bol-command "0.9.4")
+  (declare (obsolete 'evil-org-define-bol-command "0.9.4"))
   (beginning-of-line)
   (apply fun arguments)
   (evil-insert nil))


### PR DESCRIPTION
"obsolete" is not bound, and calling these obsolete functions will just emit a void-function error. It is instead a keyword that should be wrapped in a declare form.

evil-org-eol-call is probably also supposed to be replaced by evil-org-define-eol-command, not ...-bol-command.