### PR TITLE
Enable lexical binding

### DIFF
--- a/evil-org-agenda.el
+++ b/evil-org-agenda.el
@@ -1,4 +1,4 @@
-;;; evil-org-agenda.el --- evil keybindings for org-agenda-mode
+;;; evil-org-agenda.el --- evil keybindings for org-agenda-mode -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2012-2017 by Somelauw
 ;; Maintainer: Somelauw

--- a/evil-org-test.el
+++ b/evil-org-test.el
@@ -1,3 +1,5 @@
+;;; evil-org-tests.el --- Tests for Evil Org -*- lexical-binding: t
+
 (require 'evil-org)
 (require 'ert)
 

--- a/evil-org.el
+++ b/evil-org.el
@@ -1,4 +1,4 @@
-;;; evil-org.el --- evil keybindings for org-mode
+;;; evil-org.el --- evil keybindings for org-mode -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2012-2017 by Somelauw
 ;; Maintainer: Somelauw


### PR DESCRIPTION
Hi. I have inspected your codebase and I don't see  `boundp` or `bound-and-true-p` being used on lexical variables that are let-bound so dynamically. So it should be okay to enable `lexical-binding` for a free performance boost.