### PR TITLE
Prevent mark being left set after indenting

### DIFF
--- a/evil-org.el
+++ b/evil-org.el
@@ -398,7 +398,7 @@ Argument COUNT if negative, items are dedented instead."
              (= (point-at-bol) (org-list-get-top-point struct)))
         (org-list-indent-item-generic count nil struct)
       ;; indenting selected items
-      (save-excursion
+      (save-mark-and-excursion
         (when region-p (deactivate-mark))
         (set-mark beg)
         (goto-char end)


### PR DESCRIPTION
`set-mark` used, but not unset.  It has been doing this for a while.  Maybe worked at one time but newer org perhaps no longer unsets the mark.