### PR TITLE
Fix incorrect element selection

### DIFF
--- a/evil-org.el
+++ b/evil-org.el
@@ -499,7 +499,7 @@ If a prefix argument is given, links are opened in incognito mode."
 ;;; text-objects
 (defun evil-org-select-an-element (element)
   "Select an org ELEMENT."
-  (list (min (region-beginning) (org-element-property :begin element))
+  (list (min (point) (org-element-property :begin element))
         (org-element-property :end element)))
 
 (defun evil-org-select-inner-element (element)


### PR DESCRIPTION
As described in Issue #106. I still don't understand why `region-beginning` was used, but replacing it with `point` gives the exact same behavior, minus the brokenness when visual-mode has been previously activated somewhere above the subtree at point.

Fix: #106